### PR TITLE
Feat manager

### DIFF
--- a/APITaxi_front/__init__.py
+++ b/APITaxi_front/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import dateutil.parser
 import os
 import importlib

--- a/APITaxi_front/__init__.py
+++ b/APITaxi_front/__init__.py
@@ -8,6 +8,7 @@ from flask import Flask
 from flask_redis import FlaskRedis
 from flask_security import Security, SQLAlchemyUserDatastore
 from flask_wtf import FlaskForm
+from sqlalchemy.orm import joinedload
 
 import sentry_sdk
 from sentry_sdk.integrations.redis import RedisIntegration
@@ -96,5 +97,15 @@ def create_app():
     @app.context_processor
     def logout_form():
         return {'logout_form': FlaskForm()}
+
+    @app.login_manager.user_loader
+    def load_user(user_id):
+        """Like most of relationships, User.managed has the flag lazy='raise'
+        because most of the API code doesn't need to read the attribute.
+
+        The front, however, needs to read it to display the menu, so let's
+        joinedload it to make the current_user.managed attribute available.
+        """
+        return User.query.options(joinedload(User.managed)).get(user_id)
 
     return app

--- a/APITaxi_front/templates/base.html
+++ b/APITaxi_front/templates/base.html
@@ -55,7 +55,7 @@
             </li>
 
             <li class="nav-item">
-              <form action="{{ url_for('admin.logas_logout') }}" method="POST" class="form-inline">
+              <form action="{{ url_for('logout.logout') }}" method="POST" class="form-inline">
                 <button type="submit" class="btn btn-link nav-link">Déconnexion</button>
                 {{ logout_form.hidden_tag() }}
               </form>

--- a/APITaxi_front/templates/base.html
+++ b/APITaxi_front/templates/base.html
@@ -17,7 +17,7 @@
   <body>
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
       <a class="navbar-brand" href="{{ url_for('home.home') }}">Registre des taxis</a>
-      {% if request.cookies.logas_real_api_key %}
+      {% if request.cookies.logas_secrets %}
       <small class="text-danger">(Connecté en tant que {{ current_user.commercial_name or "" }} / {{ current_user.email or "" }})</small>
       {% endif %}
 

--- a/APITaxi_front/templates/base.html
+++ b/APITaxi_front/templates/base.html
@@ -17,7 +17,7 @@
   <body>
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
       <a class="navbar-brand" href="{{ url_for('home.home') }}">Registre des taxis</a>
-      {% if request.cookies.logas_secrets %}
+      {% if request.cookies.logas_sessions %}
       <small class="text-danger">(Connecté en tant que {{ current_user.commercial_name or "" }} / {{ current_user.email or "" }})</small>
       {% endif %}
 

--- a/APITaxi_front/templates/base.html
+++ b/APITaxi_front/templates/base.html
@@ -37,6 +37,12 @@
             <li class="nav-item">
                 <a class="nav-link{% if url_for('dashboards.index') in request.path %} active{% endif %}" href="{{ url_for('dashboards.index') }}">Tableaux de bord</a>
             </li>
+
+            {% if current_user.managed %}
+                <li class="nav-item">
+                    <a class="nav-link{% if url_for('manager.index') in request.path %} active{% endif %}" href="{{ url_for('manager.index') }}">Gestion des opérateurs</a>
+                </li>
+            {% endif %}
             {% endif %}
 
             <li class="nav-item">

--- a/APITaxi_front/templates/manager/base.html
+++ b/APITaxi_front/templates/manager/base.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+
+{% block title %}Tableaux de bord{% endblock %}
+
+{% block content %}
+<div class="page-sidebar">
+  <nav>
+    <div class="menu-category">Tableaux de bord</div>
+    <ul class="list-unstyled">
+        <li><a{% if request.path == url_for('manager.logas') %} class="active"{% endif %} href="{{ url_for('manager.logas') }}">Log-as</a></li>
+    </ul>
+  </nav>
+
+  <main>
+  {% block main %}{% endblock %}
+  </main>
+</div>
+{% endblock %}

--- a/APITaxi_front/templates/manager/logas.html
+++ b/APITaxi_front/templates/manager/logas.html
@@ -1,0 +1,87 @@
+{% extends "manager/base.html" %}
+{% import "/macros/csrf.html" as csrf %}
+
+{% block main %}
+
+<p>Cette page vous permet de vous connecter aux comptes dont vous avez la gestion. Une fois connecté, déconnectez-vous pour revenir sur votre compte.</p>
+
+<div class="search-panel">
+  <h5>Filtres</h5>
+  <form class="d-flex flex-wrap" autocomplete="off">
+    <div class="form-group">
+      <label for="search_email">Email</label>
+      <input data-filter-col="email" id="search_email" type="text" class="form-control" placeholder="Email" />
+    </div>
+    <div class="form-group">
+      <label for="search_commercial_name">Nom commercial</label>
+      <input data-filter-col="commercial_name" id="search_commercial_name" type="text" class="form-control" placeholder="Nom commercial" />
+    </div>
+  </form>
+</div>
+
+<table id="table" class="table table-striped">
+  <thead>
+    <tr>
+      <th>Email</th>
+      <th>Nom commercial</th>
+      <th>Action</th>
+    </tr>
+  </thead>
+</table>
+{% endblock %}
+
+{% block scripts %}
+var table = $('#table').DataTable({
+  language: {
+    emptyTable: 'Aucun utilisateur',
+    loadingRecords: 'Chargement en cours...',
+    zeroRecords: 'Aucun résultat trouvé',
+    paginate: {
+      previous: '&lt;',
+      next: '&gt;'
+    }
+  },
+  // Remove sorting.
+  bSort: false,
+  // Number of items per page.
+  pageLength: 50,
+  // Do not filter or paginate client side, send query for each draw.
+  serverSide: true,
+  // Elements to display for the table. Reference: https://datatables.net/reference/option/dom
+  // tp: display 't'able and 'p'agination. Other default items (info, search
+  // input, ...) are not displayed.
+  sDom: 'tp',
+  // API endpoint called.
+  ajax: {
+    url: "{{ url_for('api.users') }}?manager",
+    dataSrc: 'data'
+  },
+  // Mapping between API response and columns.
+  columns: [
+    {name: 'email', data: 'email'},
+    {name: 'commercial_name', data: 'commercial_name'},
+    {
+      data: null,
+      fnCreatedCell: function (nTd, sData, oData, iRow, iCol) {
+        $(nTd).html(`
+          {{ csrf.csrf_error(logas_form) }}
+          <form method="POST" action="{{ url_for('manager.logas') }}">
+            {{ logas_form.hidden_tag() }}
+            <input type="hidden" name="{{ logas_form.user_id.name }}" value="` + sData.id + `" />
+            <button type="submit" class="btn btn-primary">Connexion</button>
+          </form>
+        `)
+      }
+    }
+  ]
+});
+
+// Iterate over inputs from search-panel, and call API to filter results.
+$('.search-panel input').each(function() {
+  $(this).on('keyup change clear', function() {
+    if (this.value != table.column(this.dataset.filterCol).search()) {
+      table.column(this.dataset.filterCol + ':name').search(this.value).draw();
+    }
+  });
+});
+{% endblock %}

--- a/APITaxi_front/templates/profile.html
+++ b/APITaxi_front/templates/profile.html
@@ -34,6 +34,19 @@
 
     <h6>Général</h6>
 
+    <!-- Email -->
+    <div class="d-flex align-items-center">
+      <div class="flex-even">
+        <div class="form-group">
+          <label>Identifiant</label>
+          <div>{{ user.email }}</div>
+        </div>
+      </div>
+      <div class="flex-even formdoc">
+          Identifiant utilisé pour vous connecter. Vous ne pouvez pas en changer.
+      </div>
+    </div>
+
     <!-- Commercial name -->
     <div class="d-flex align-items-center">
       <div class="flex-even">

--- a/APITaxi_front/templates/profile.html
+++ b/APITaxi_front/templates/profile.html
@@ -20,6 +20,14 @@
 
   <hr />
 
+  {% if manager %}
+  <h3>Gestionnaire de compte</h3>
+
+  <p>Votre compte est géré par <strong>{{ manager.commercial_name or manager.email }}</strong> qui peut accéder à votre profil, votre clé d'API, et effectuer des requêtes pour vous. S'il vous pensez qu'il s'agit d'une erreur, contactez-nous sur <i>equipe@le.taxi</i>.</p>
+
+  <hr />
+  {% endif %}
+
   <h3>Mes paramètres </h3>
 
   <form method="POST" novalidate autocomplete="off">

--- a/APITaxi_front/tests/conftest.py
+++ b/APITaxi_front/tests/conftest.py
@@ -77,7 +77,7 @@ def _create_client(app, roles):
 
 @pytest.fixture
 def anonymous(app):
-    yield from _create_client(app, [])
+    yield from _create_client(app, None)
 
 
 @pytest.fixture

--- a/APITaxi_front/tests/conftest.py
+++ b/APITaxi_front/tests/conftest.py
@@ -81,6 +81,12 @@ def anonymous(app):
 
 
 @pytest.fixture
+def no_roles(app):
+    """Authenticated user without any roles."""
+    yield from _create_client(app, [])
+
+
+@pytest.fixture
 def admin(app):
     yield from _create_client(app, ['admin'])
 

--- a/APITaxi_front/tests/test_admin.py
+++ b/APITaxi_front/tests/test_admin.py
@@ -1,6 +1,9 @@
+import json
+
 from flask_security import current_user
 
-from APITaxi_models2.unittest.factories import UserFactory
+from APITaxi_models2 import RolesUsers, User
+from APITaxi_models2.unittest.factories import RoleFactory, RolesUsersFactory, UserFactory
 
 
 def test_logas_feature(admin, moteur, operateur):
@@ -36,3 +39,53 @@ def test_logas_feature(admin, moteur, operateur):
     resp = admin.client.post('/logas/logout')
     assert resp.status_code == 302
     assert current_user.is_anonymous
+
+
+def test_logout_deleted_user(admin):
+    """Attempt to logout to a non-existing user."""
+    other_admin = UserFactory()
+    RolesUsersFactory(role=RoleFactory(name='admin'), user=other_admin)
+
+    user = UserFactory()
+
+    # Log as the manager
+    resp = admin.client.post('/admin/logas', data={'user_id': other_admin.id})
+    assert current_user.id == other_admin.id
+    assert resp.status_code == 302
+
+    # Log as the user
+    resp = admin.client.post('/admin/logas', data={'user_id': user.id})
+    assert current_user.id == user.id
+    assert resp.status_code == 302
+
+    RolesUsers.query.filter_by(user=other_admin).delete()
+    User.query.filter_by(id=other_admin.id).delete()
+
+    # Logout as the admin, which doesn't exist anymore.
+    resp = admin.client.post('/logas/logout')
+    assert resp.status_code == 302
+    assert current_user.is_anonymous
+    # logas_sessions is emptied, and user is logged out.
+    for header in resp.headers.getlist('set-cookie'):
+        assert 'logas_sessions=;' in header or 'session=;' in header
+
+
+def test_security(admin):
+    """Attempt to alter cookies to gain privileges."""
+    new_user = UserFactory()
+
+    # Log-as the new user
+    resp = admin.client.post('/admin/logas', data={'user_id': new_user.id})
+    assert current_user.id == new_user.id
+    assert resp.status_code == 302
+
+    admin.client.set_cookie('localhost', 'logas_sessions', json.dumps([
+        'altered'
+    ]))
+
+    # Try to logout: 400 response, logas_sessions cookie is emptied, and user
+    # is logged out.
+    resp = admin.client.post('/logas/logout')
+    assert resp.status_code == 400
+    for header in resp.headers.getlist('set-cookie'):
+        assert 'logas_sessions=;' in header or 'session=;' in header

--- a/APITaxi_front/tests/test_manager.py
+++ b/APITaxi_front/tests/test_manager.py
@@ -1,0 +1,44 @@
+from flask_security import current_user
+
+from APITaxi_models2 import db
+from APITaxi_models2.unittest.factories import UserFactory
+
+
+def test_logas_feature(operateur):
+    # Not a manager
+    resp = operateur.client.get('/manager/logas')
+    assert resp.status_code == 302
+
+    non_managed_user = UserFactory()
+
+    managed_user = UserFactory(manager=operateur.user)
+    db.session.refresh(operateur.user)
+
+    # It is now possible to list user
+    resp = operateur.client.get('/manager/logas')
+    assert resp.status_code == 200
+
+    # Try to log-as a non-existing user
+    resp = operateur.client.post('/manager/logas', data={'user_id': 9999999})
+    assert current_user.id == operateur.user.id
+    assert resp.status_code == 404
+
+    # Try to log-as a non-managed user
+    resp = operateur.client.post('/manager/logas', data={'user_id': non_managed_user.id})
+    assert current_user.id == operateur.user.id
+    assert resp.status_code == 404
+
+    # Try to log-as the new user
+    resp = operateur.client.post('/manager/logas', data={'user_id': managed_user.id})
+    assert current_user.id == managed_user.id
+    assert resp.status_code == 302
+
+    # Try to logout
+    resp = operateur.client.post('/logas/logout')
+    assert resp.status_code == 302
+    assert current_user.id == operateur.user.id
+
+    # Try to logout again from the origin account
+    resp = operateur.client.post('/logas/logout')
+    assert resp.status_code == 302
+    assert current_user.is_anonymous

--- a/APITaxi_front/tests/test_manager.py
+++ b/APITaxi_front/tests/test_manager.py
@@ -4,41 +4,41 @@ from APITaxi_models2 import db
 from APITaxi_models2.unittest.factories import UserFactory
 
 
-def test_logas_feature(operateur):
+def test_logas_feature(no_roles):
     # Not a manager
-    resp = operateur.client.get('/manager/logas')
+    resp = no_roles.client.get('/manager/logas')
     assert resp.status_code == 302
 
     non_managed_user = UserFactory()
 
-    managed_user = UserFactory(manager=operateur.user)
-    db.session.refresh(operateur.user)
+    managed_user = UserFactory(manager=no_roles.user)
+    db.session.refresh(no_roles.user)
 
     # It is now possible to list user
-    resp = operateur.client.get('/manager/logas')
+    resp = no_roles.client.get('/manager/logas')
     assert resp.status_code == 200
 
     # Try to log-as a non-existing user
-    resp = operateur.client.post('/manager/logas', data={'user_id': 9999999})
-    assert current_user.id == operateur.user.id
+    resp = no_roles.client.post('/manager/logas', data={'user_id': 9999999})
+    assert current_user.id == no_roles.user.id
     assert resp.status_code == 404
 
     # Try to log-as a non-managed user
-    resp = operateur.client.post('/manager/logas', data={'user_id': non_managed_user.id})
-    assert current_user.id == operateur.user.id
+    resp = no_roles.client.post('/manager/logas', data={'user_id': non_managed_user.id})
+    assert current_user.id == no_roles.user.id
     assert resp.status_code == 404
 
     # Try to log-as the new user
-    resp = operateur.client.post('/manager/logas', data={'user_id': managed_user.id})
+    resp = no_roles.client.post('/manager/logas', data={'user_id': managed_user.id})
     assert current_user.id == managed_user.id
     assert resp.status_code == 302
 
     # Try to logout
-    resp = operateur.client.post('/logas/logout')
+    resp = no_roles.client.post('/logas/logout')
     assert resp.status_code == 302
-    assert current_user.id == operateur.user.id
+    assert current_user.id == no_roles.user.id
 
     # Try to logout again from the origin account
-    resp = operateur.client.post('/logas/logout')
+    resp = no_roles.client.post('/logas/logout')
     assert resp.status_code == 302
     assert current_user.is_anonymous

--- a/APITaxi_front/tests/test_profile.py
+++ b/APITaxi_front/tests/test_profile.py
@@ -1,7 +1,9 @@
 from flask_security.utils import verify_password
 
+from APITaxi_models2 import db
 
-def test_profile(operateur):
+
+def test_profile(operateur, moteur):
     resp = operateur.client.get('/profile')
     assert resp.status_code == 200
 
@@ -37,3 +39,12 @@ def test_profile(operateur):
     assert operateur.user.hail_endpoint_production == 'http://xxx'
     assert operateur.user.operator_header_name == 'X-Header'
     assert operateur.user.operator_api_key == 'MyApiKey'
+
+    # Operateur doesn't have an account manager.
+    assert 'Gestionnaire de compte' not in resp.data.decode('utf8')
+
+    # If we set an account manager, it should be displayed on the profile page.
+    operateur.user.manager_id = moteur.user.id
+    db.session.commit()
+    resp = operateur.client.get('/profile')
+    assert 'Gestionnaire de compte' in resp.data.decode('utf8')

--- a/APITaxi_front/views/admin.py
+++ b/APITaxi_front/views/admin.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from flask import Blueprint, redirect, url_for
 from flask_security import login_required, roles_accepted
 

--- a/APITaxi_front/views/admin.py
+++ b/APITaxi_front/views/admin.py
@@ -1,14 +1,11 @@
 # -*- coding: utf-8 -*-
 
-from flask import Blueprint, redirect, request, url_for
-from flask_login import login_user
-import flask_security
+from flask import Blueprint, redirect, url_for
 from flask_security import login_required, roles_accepted
-from wtforms import IntegerField
 
 from APITaxi_models2 import User
 
-from .generic.logas import LogAsView, LogoutAsView
+from .generic.logas import LogAsView
 
 
 blueprint = Blueprint('admin', __name__)

--- a/APITaxi_front/views/admin.py
+++ b/APITaxi_front/views/admin.py
@@ -37,9 +37,7 @@ class AdminLogAs(LogAsView):
 
     template_name = 'admin/logas.html'
     user_model = User
-
-    def get_redirect_on_success(self):
-        return url_for('home.home')
+    redirect_on_success = 'home.home'
 
 
 blueprint.add_url_rule(
@@ -51,10 +49,8 @@ blueprint.add_url_rule(
 
 class Logout(LogoutAsView):
 
+    redirect_on_success = 'home.home'
     user_model = User
-
-    def get_redirect_on_success(self):
-        return url_for('home.home')
 
 
 blueprint.add_url_rule(

--- a/APITaxi_front/views/admin.py
+++ b/APITaxi_front/views/admin.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import json
-
 from flask import Blueprint, redirect, request, url_for
 from flask_login import login_user
 import flask_security
@@ -11,7 +9,7 @@ from wtforms import IntegerField
 
 from APITaxi_models2 import User
 
-from .generic.logas import LogAsView, load_logas_cookie
+from .generic.logas import LogAsView, load_logas_cookie, set_logas_cookie
 
 
 blueprint = Blueprint('admin', __name__)
@@ -77,13 +75,7 @@ def logas_logout():
             login_user(user)
 
         logas_api_keys.pop(0)
-        if not logas_api_keys:
-            response.delete_cookie('logas_real_api_key')
-        else:
-            response.set_cookie(
-                'logas_real_api_key',
-                json.dumps(logas_api_keys)
-            )
+        set_logas_cookie(response, logas_api_keys)
 
         return response
 

--- a/APITaxi_front/views/admin.py
+++ b/APITaxi_front/views/admin.py
@@ -45,15 +45,3 @@ blueprint.add_url_rule(
     view_func=AdminLogAs.as_view('logas'),
     methods=['GET', 'POST']
 )
-
-
-class Logout(LogoutAsView):
-    user_model = User
-    redirect_on_success = 'home.home'
-
-
-blueprint.add_url_rule(
-    '/logas/logout',
-    view_func=Logout.as_view('logas_logout'),
-    methods=['POST']
-)

--- a/APITaxi_front/views/admin.py
+++ b/APITaxi_front/views/admin.py
@@ -48,9 +48,8 @@ blueprint.add_url_rule(
 
 
 class Logout(LogoutAsView):
-
-    redirect_on_success = 'home.home'
     user_model = User
+    redirect_on_success = 'home.home'
 
 
 blueprint.add_url_rule(

--- a/APITaxi_front/views/admin.py
+++ b/APITaxi_front/views/admin.py
@@ -4,7 +4,6 @@ from flask import Blueprint, redirect, request, url_for
 from flask_login import login_user
 import flask_security
 from flask_security import login_required, roles_accepted
-from flask_wtf import FlaskForm
 from wtforms import IntegerField
 
 from APITaxi_models2 import User
@@ -20,10 +19,6 @@ blueprint = Blueprint('admin', __name__)
 @roles_accepted('admin')
 def index():
     return redirect(url_for('admin.logas'))
-
-
-class LogAsForm(FlaskForm):
-    user_id = IntegerField()
 
 
 class AdminLogAs(LogAsView):

--- a/APITaxi_front/views/admin.py
+++ b/APITaxi_front/views/admin.py
@@ -59,9 +59,6 @@ def logas_logout():
 
     If the user is logged with the "logas" feature, we attempt to reconnect the
     user back to his previous session.
-
-    For security purpose, this must be a POST endpoint.
-    Without CSRF validation, an attacker can redirect a logged-in user to force him to logout.
     """
     # CSRF Validation
     form = FlaskForm()

--- a/APITaxi_front/views/api.py
+++ b/APITaxi_front/views/api.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """This module gathers JSON endpoints, used by AJAX calls.
 """
 

--- a/APITaxi_front/views/api.py
+++ b/APITaxi_front/views/api.py
@@ -133,11 +133,26 @@ def check_datatables_arguments(func):
 
 @blueprint.route('/api/users', methods=['GET'])
 @login_required
-@roles_accepted('admin')
 @check_datatables_arguments
 def users(length, start, draw, columns=None):
-    """Administration endpoint to list users."""
-    query = User.query.order_by(User.id)
+    """List users.
+
+    This endpoint doesn't call @roles_accepted, but requires the user to be
+    either an administrator or a manager:
+
+    - if user manages other accounts and ?manager is set in querystring, only
+    return the list of managed users
+    - if user is administrator, returns all users
+
+    Otherwise, returns an empty list.
+    """
+    if 'manager' in request.args and current_user.managed:
+        query = User.query.filter(User.id.in_([user.id for user in current_user.managed])).order_by(User.id)
+    elif current_user.has_role('admin'):
+        query = User.query.order_by(User.id)
+    else:
+        query = User.query.filter(False)
+
     records_total = query.count()
 
     commercial_name_filter = get_datatables_filter('commercial_name', columns)

--- a/APITaxi_front/views/dashboards.py
+++ b/APITaxi_front/views/dashboards.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from datetime import datetime, timedelta
 import itertools
 import json

--- a/APITaxi_front/views/generic/logas.py
+++ b/APITaxi_front/views/generic/logas.py
@@ -124,8 +124,7 @@ class LogAsView(View, LogAsCookieMixin, LogAsRedirectMixin, LogAsSQLAUserMixin):
             self.store_logas_sessions(response, [current_session] + logas_sessions)
 
             # Login as the new user, and update the response cookie.
-            login_user(user)
-            current_app.login_manager._set_cookie(response)
+            login_user(user, remember=True)
 
             return response
 

--- a/APITaxi_front/views/generic/logas.py
+++ b/APITaxi_front/views/generic/logas.py
@@ -2,7 +2,7 @@
 
 import json
 
-from flask import abort, redirect, render_template, request, Response
+from flask import abort, redirect, render_template, request, Response, url_for
 from flask_login import login_user
 import flask_security
 from flask_security import current_user
@@ -40,14 +40,20 @@ class LogAsCookieMixin:
         return keys
 
 
-class LogAsView(View, LogAsCookieMixin):
+class LogAsRedirectMixin:
+
+    redirect_on_success = None
+
+    def get_redirect_on_success(self):
+        if self.redirect_on_success:
+            return url_for(self.redirect_on_success)
+        return '/'
+
+
+class LogAsView(View, LogAsCookieMixin, LogAsRedirectMixin):
 
     user_model = None
     template_name = None
-    redirect_on_success = '/'
-
-    def get_redirect_on_success(self):
-        return self.redirect_on_success
 
     def get_users_query(self):
         """Override to specify the query to limit the users possible to log as."""
@@ -78,13 +84,9 @@ class LogAsView(View, LogAsCookieMixin):
         return render_template(self.template_name, logas_form=form)
 
 
-class LogoutAsView(View, LogAsCookieMixin):
+class LogoutAsView(View, LogAsCookieMixin, LogAsRedirectMixin):
 
-    redirect_on_success = '/'
     user_model = None
-
-    def get_redirect_on_success(self):
-        return self.redirect_on_success
 
     def get_user_model(self):
         if not self.user_model:

--- a/APITaxi_front/views/generic/logas.py
+++ b/APITaxi_front/views/generic/logas.py
@@ -51,10 +51,6 @@ class LogAsView(View):
             raise NotImplementedError('You should override template_name or get_template_name()')
         return self.template_name
 
-    def get_users_model(self):
-        """SQLAlchemy User model."""
-        return self.user_model
-
     def get_users_query(self):
         """Override to specify the query to limit the users possible to log as."""
         if not self.user_model:

--- a/APITaxi_front/views/generic/logas.py
+++ b/APITaxi_front/views/generic/logas.py
@@ -131,7 +131,9 @@ class LogoutAsView(View, LogAsCookieMixin, LogAsRedirectMixin, LogAsSQLAUserMixi
         if not logas_secrets:
             return flask_security.views.logout()
 
-        user_filter = {self.user_secret_attr: logas_secrets[0]}
+        secret = logas_secrets.pop(0)
+
+        user_filter = {self.user_secret_attr: secret}
         user = self.get_users_query().filter_by(**user_filter).first()
         if not user:
             response = flask_security.views.logout()
@@ -139,7 +141,5 @@ class LogoutAsView(View, LogAsCookieMixin, LogAsRedirectMixin, LogAsSQLAUserMixi
             response = redirect(self.get_redirect_on_success())
             login_user(user)
 
-        logas_secrets.pop(0)
         self.set_logas_cookie(response, logas_secrets)
-
         return response

--- a/APITaxi_front/views/generic/logas.py
+++ b/APITaxi_front/views/generic/logas.py
@@ -17,13 +17,13 @@ class LogAsForm(FlaskForm):
 
 class LogAsCookieMixin:
 
-    cookie_name = 'logas_real_api_key'
+    cookie_name = 'logas_secrets'
 
-    def set_logas_cookie(self, response, logas_api_keys):
-        if not logas_api_keys:
+    def set_logas_cookie(self, response, logas_secrets):
+        if not logas_secrets:
             response.delete_cookie(self.cookie_name)
         else:
-            response.set_cookie(self.cookie_name, json.dumps(logas_api_keys))
+            response.set_cookie(self.cookie_name, json.dumps(logas_secrets))
 
     def load_logas_cookie(self):
         value = request.cookies.get(self.cookie_name)
@@ -101,11 +101,11 @@ class LogoutAsView(View, LogAsCookieMixin, LogAsRedirectMixin, LogAsSQLAUserMixi
         if not form.validate_on_submit():
             return redirect('/')
 
-        logas_api_keys = self.load_logas_cookie()
-        if not logas_api_keys:
+        logas_secrets = self.load_logas_cookie()
+        if not logas_secrets:
             return flask_security.views.logout()
 
-        user_filter = {self.user_secret_attr: logas_api_keys[0]}
+        user_filter = {self.user_secret_attr: logas_secrets[0]}
         user = self.get_users_query().filter_by(**user_filter).first()
         if not user:  # bad API key
             response = flask_security.views.logout()
@@ -113,7 +113,7 @@ class LogoutAsView(View, LogAsCookieMixin, LogAsRedirectMixin, LogAsSQLAUserMixi
             response = redirect(self.get_redirect_on_success())
             login_user(user)
 
-        logas_api_keys.pop(0)
-        self.set_logas_cookie(response, logas_api_keys)
+        logas_secrets.pop(0)
+        self.set_logas_cookie(response, logas_secrets)
 
         return response

--- a/APITaxi_front/views/generic/logas.py
+++ b/APITaxi_front/views/generic/logas.py
@@ -16,32 +16,43 @@ class LogAsForm(FlaskForm):
 
 
 class LogAsCookieMixin:
+    """Mixin to manipulate logas cookies.
 
+    logas_secrets is a cookie which stores a list of secrets.
+
+    On log-as, the current user's secret is stored in logas_secrets for later
+    retrieval before login.
+
+    On logout, the secret is retrieved from logas_secrets to login user.
+    """
     cookie_name = 'logas_secrets'
 
     def set_logas_cookie(self, response, logas_secrets):
+        """Store the list of secrets in response cookie."""
         if not logas_secrets:
             response.delete_cookie(self.cookie_name)
         else:
             response.set_cookie(self.cookie_name, json.dumps(logas_secrets))
 
     def load_logas_cookie(self):
+        """Loads the list of secrets from request cookie."""
         value = request.cookies.get(self.cookie_name)
         if not value:
             return []
+        # Value has been crafted and is not JSON: assume it is empty.
         try:
-            keys = json.loads(value)
+            logas_secrets = json.loads(value)
         except json.decoder.JSONDecodeError:
             return []
-
-        if not isinstance(keys, list):
+        # Value is JSON but has been crafted and is not a list: assume it is
+        # empty.
+        if not isinstance(logas_secrets, list):
             return []
-
-        return keys
+        return logas_secrets
 
 
 class LogAsRedirectMixin:
-
+    """Mixin to redirect user when logas or logout is successful."""
     redirect_on_success = None
 
     def get_redirect_on_success(self):
@@ -51,13 +62,15 @@ class LogAsRedirectMixin:
 
 
 class LogAsSQLAUserMixin:
-
     user_model = None
     user_id_attr = 'id'
     user_secret_attr = 'apikey'
 
     def get_users_query(self):
-        """Override to specify the query to limit the users possible to log as."""
+        """List users. Returns <user_model>.query by default, which returns all
+        users.
+
+        To only allow log-as to a subset of users, return a filtered query."""
         if not self.user_model:
             raise NotImplementedError('You should override user_model or get_users_query()')
         return self.user_model.query
@@ -73,6 +86,14 @@ class LogAsView(View, LogAsCookieMixin, LogAsRedirectMixin, LogAsSQLAUserMixin):
     template_name = None
 
     def dispatch_request(self):
+        """For GET requests, return template_name.
+
+        For POST requests:
+
+        - get the User object with the user_id provided
+        - store the current user secret in cookie
+        - login as the User
+        """
         form = LogAsForm()
 
         if form.validate_on_submit():
@@ -97,6 +118,11 @@ class LogAsView(View, LogAsCookieMixin, LogAsRedirectMixin, LogAsSQLAUserMixin):
 class LogoutAsView(View, LogAsCookieMixin, LogAsRedirectMixin, LogAsSQLAUserMixin):
 
     def dispatch_request(self):
+        """If there is no secret stored in cookie, simple logout.
+
+        Otherwise, pop the first secret from the list of secrets stored in
+        cookies, and identify as the user with this secret.
+        """
         form = FlaskForm()
         if not form.validate_on_submit():
             return redirect('/')
@@ -107,7 +133,7 @@ class LogoutAsView(View, LogAsCookieMixin, LogAsRedirectMixin, LogAsSQLAUserMixi
 
         user_filter = {self.user_secret_attr: logas_secrets[0]}
         user = self.get_users_query().filter_by(**user_filter).first()
-        if not user:  # bad API key
+        if not user:
             response = flask_security.views.logout()
         else:
             response = redirect(self.get_redirect_on_success())

--- a/APITaxi_front/views/generic/logas.py
+++ b/APITaxi_front/views/generic/logas.py
@@ -1,0 +1,60 @@
+"""Generic views for the LogAs feature."""
+
+from flask import abort, redirect, render_template, Response
+from flask_login import login_user
+from flask_security import current_user
+from flask.views import View
+from flask_wtf import FlaskForm
+from wtforms import IntegerField
+
+
+class LogAsForm(FlaskForm):
+    user_id = IntegerField()
+
+
+class LogAsView(View):
+
+    user_model = None
+    template_name = None
+    redirect_on_success = '/'
+
+    def get_redirect_on_success(self):
+        return self.redirect_on_success
+
+    def get_template_name(self):
+        """Template to render."""
+        if not self.template_name:
+            raise NotImplementedError('You should override template_name or get_template_name()')
+        return self.template_name
+
+    def get_users_model(self):
+        """SQLAlchemy User model."""
+        return self.user_model
+
+    def get_users_query(self):
+        """Override to specify the query to limit the users possible to log as."""
+        if not self.user_model:
+            raise NotImplementedError('You should override user_model or get_users_query()')
+        return self.user_model.query
+
+    def get_user(self, query, user_id):
+        """Given a query on the user model, get the user instance."""
+        return query.filter_by(id=user_id).one_or_none()
+
+    def dispatch_request(self):
+        form = LogAsForm()
+
+        if form.validate_on_submit():
+            query = self.get_users_query()
+            user = self.get_user(query, form.user_id.data)
+
+            if not user:
+                abort(Response('Invalid user', status=404))
+
+            response = redirect(self.get_redirect_on_success())
+            response.set_cookie('logas_real_api_key', current_user.apikey)
+
+            login_user(user)
+            return response
+
+        return render_template(self.get_template_name(), logas_form=form)

--- a/APITaxi_front/views/generic/logas.py
+++ b/APITaxi_front/views/generic/logas.py
@@ -77,7 +77,6 @@ class LogAsRedirectMixin:
 
 class LogAsSQLAUserMixin:
     user_model = None
-    user_id_attr = 'id'
 
     def get_users_query(self):
         """List users. Returns <user_model>.query by default, which returns all
@@ -90,8 +89,7 @@ class LogAsSQLAUserMixin:
 
     def get_user(self, query, user_id):
         """Given a query on the user model, get the user instance."""
-        filters = {self.user_id_attr: user_id}
-        return query.filter_by(**filters).one_or_none()
+        return query.filter_by(id=user_id).one_or_none()
 
 
 class LogAsView(View, LogAsCookieMixin, LogAsRedirectMixin, LogAsSQLAUserMixin):

--- a/APITaxi_front/views/generic/logas.py
+++ b/APITaxi_front/views/generic/logas.py
@@ -49,12 +49,6 @@ class LogAsView(View, LogAsCookieMixin):
     def get_redirect_on_success(self):
         return self.redirect_on_success
 
-    def get_template_name(self):
-        """Template to render."""
-        if not self.template_name:
-            raise NotImplementedError('You should override template_name or get_template_name()')
-        return self.template_name
-
     def get_users_query(self):
         """Override to specify the query to limit the users possible to log as."""
         if not self.user_model:
@@ -81,7 +75,7 @@ class LogAsView(View, LogAsCookieMixin):
             login_user(user)
             return response
 
-        return render_template(self.get_template_name(), logas_form=form)
+        return render_template(self.template_name, logas_form=form)
 
 
 class LogoutAsView(View, LogAsCookieMixin):

--- a/APITaxi_front/views/generic/logas.py
+++ b/APITaxi_front/views/generic/logas.py
@@ -56,7 +56,7 @@ class LogAsCookieMixin:
     def get_current_session(self):
         """Get the value of flask_login remember_token. On logas, this value is
         saved. On logout, we use
-        flask_login.login_maanger._load_user_from_remember_cookie() to login.
+        flask_login.login_manager._load_user_from_remember_cookie() to login.
         """
         remember_cookie_name = current_app.config.get(
             'REMEMBER_COOKIE_NAME', flask_login.COOKIE_NAME

--- a/APITaxi_front/views/generic/logas.py
+++ b/APITaxi_front/views/generic/logas.py
@@ -29,6 +29,13 @@ def load_logas_cookie(cookies):
     return keys
 
 
+def set_logas_cookie(response, logas_api_keys):
+    if not logas_api_keys:
+        response.delete_cookie('logas_real_api_key')
+    else:
+        response.set_cookie('logas_real_api_key', json.dumps(logas_api_keys))
+
+
 class LogAsView(View):
 
     user_model = None
@@ -70,11 +77,7 @@ class LogAsView(View):
                 abort(Response('Invalid user', status=404))
 
             response = redirect(self.get_redirect_on_success())
-
-            response.set_cookie(
-                'logas_real_api_key',
-                json.dumps([current_user.apikey] + load_logas_cookie(request.cookies))
-            )
+            set_logas_cookie(response, [current_user.apikey] + load_logas_cookie(request.cookies))
 
             login_user(user)
             return response

--- a/APITaxi_front/views/generic/logas.py
+++ b/APITaxi_front/views/generic/logas.py
@@ -64,7 +64,7 @@ class LogAsRedirectMixin:
 class LogAsSQLAUserMixin:
     user_model = None
     user_id_attr = 'id'
-    user_secret_attr = 'apikey'
+    user_secret_attr = 'password'
 
     def get_users_query(self):
         """List users. Returns <user_model>.query by default, which returns all

--- a/APITaxi_front/views/generic/logas.py
+++ b/APITaxi_front/views/generic/logas.py
@@ -145,7 +145,7 @@ class LogoutAsView(View, LogAsCookieMixin, LogAsRedirectMixin, LogAsSQLAUserMixi
         except itsdangerous.exc.BadSignature:
             response = flask_security.views.logout()
             self.store_logas_sessions(response, [])
-            return response
+            return response, 400
 
         user = self.get_user(self.get_users_query(), last_logas_session['_user_id'])
         # Cookie is valid, but user has been deleted. Remove all logas sessions

--- a/APITaxi_front/views/logout.py
+++ b/APITaxi_front/views/logout.py
@@ -1,0 +1,20 @@
+from flask import Blueprint
+
+from .generic.logas import LogoutAsView
+
+from APITaxi_models2 import User
+
+
+blueprint = Blueprint('logout', __name__)
+
+
+class Logout(LogoutAsView):
+    user_model = User
+    redirect_on_success = 'home.home'
+
+
+blueprint.add_url_rule(
+    '/logas/logout',
+    view_func=Logout.as_view('logout'),
+    methods=['POST']
+)

--- a/APITaxi_front/views/manager.py
+++ b/APITaxi_front/views/manager.py
@@ -1,0 +1,48 @@
+import functools
+
+from flask import Blueprint, current_app, redirect, url_for
+from flask_security import current_user, login_required
+
+from APITaxi_models2 import User
+
+from .generic.logas import LogAsView
+
+
+blueprint = Blueprint('manager', __name__)
+
+
+@blueprint.route('/manager', methods=['GET'])
+@login_required
+def index():
+    return redirect(url_for('manager.logas'))
+
+
+def require_manager(func):
+    """Redirect to login page if user is not an account manager."""
+    @functools.wraps(func)
+    def wrapped(*args, **kwargs):
+        if current_user.is_authenticated and current_user.managed:
+            return func(*args, **kwargs)
+        return current_app.login_manager.unauthorized()
+    return wrapped
+
+
+class ManagerLogAs(LogAsView):
+    decorators = [
+        login_required,
+        require_manager
+    ]
+
+    template_name = 'manager/logas.html'
+    redirect_on_success = 'home.home'
+
+    def get_users_query(self):
+        """Only allow logas users managed by this user."""
+        return User.query.filter(User.id.in_([user.id for user in current_user.managed]))
+
+
+blueprint.add_url_rule(
+    '/manager/logas',
+    view_func=ManagerLogAs.as_view('logas'),
+    methods=['GET', 'POST']
+)

--- a/APITaxi_front/views/profile.py
+++ b/APITaxi_front/views/profile.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import re
 
 from flask import (

--- a/APITaxi_front/views/profile.py
+++ b/APITaxi_front/views/profile.py
@@ -16,7 +16,7 @@ from flask_security.utils import hash_password
 from flask_wtf import FlaskForm
 from wtforms import PasswordField, StringField, ValidationError, validators
 
-from APITaxi_models2 import db
+from APITaxi_models2 import db, User
 
 
 blueprint = Blueprint('profile', __name__)
@@ -119,4 +119,8 @@ def edit():
         flash("Paramètres modifiés avec succès.", 'primary')
         return redirect(url_for('profile.edit'))
 
-    return render_template('profile.html', user=current_user, form=form)
+    manager = None
+    if current_user.manager_id:
+        manager = User.query.filter_by(id=current_user.manager_id).one()
+
+    return render_template('profile.html', user=current_user, form=form, manager=manager)


### PR DESCRIPTION
# Previous state

Administrators have a special page to list users, and can log as any user.
On log as, the current user's API key (ie. the administrator's API key) is stored in cookie.
On log out:
* if an API key is stored on cookie, get the value, find the user with this API key, and login as this user
* otherwise, normal logout

Only one API key can be stored, so if admin A logs as admin B, then logs as user C, it is not possible to logout 2 times to become admin A again.

# Current state

* refactoring : LogAsView uses flask generic views to avoid duplication
* allow nesting logas
* instead of storing the current user's API key in cookie, we store the session id which is much less sensitive
* create the page "Gestion des opérateurs" for managers. Mangers can log as the users they manage